### PR TITLE
Make a way to suppress MA0003

### DIFF
--- a/MemoryAnalyzers/MemoryAnalyzers/MemoryAnalyzer.cs
+++ b/MemoryAnalyzers/MemoryAnalyzers/MemoryAnalyzer.cs
@@ -178,6 +178,8 @@ namespace MemoryAnalyzers
 			var rightInfo = context.SemanticModel.GetSymbolInfo(assignment.Right);
 			if (rightInfo.Symbol is not IMethodSymbol methodSymbol || methodSymbol.IsStatic)
 				return; // static methods are fine
+			if (HasUnconditionalSuppressMessage(methodSymbol, MA0003))
+				return; // Method has [UnconditionalSuppressMessage]
 			if (!IsNSObjectSubclass(methodSymbol.ContainingType))
 				return; // If the method is on a non-NSObject subclass, it's fine
 
@@ -203,7 +205,7 @@ namespace MemoryAnalyzers
 			{
 				if (attribute.AttributeClass is null)
 					continue;
-				if (attribute.AttributeClass.ContainingNamespace.Name != "System.Diagnostics.CodeAnalysis")
+				if (attribute.AttributeClass.ContainingNamespace.ToString() != "System.Diagnostics.CodeAnalysis")
 					continue;
 				if (attribute.AttributeClass.Name != "UnconditionalSuppressMessageAttribute")
 					continue;


### PR DESCRIPTION
I add a test to allow:

    new UITextField().EditingDidBegin += _proxy.OnEditingDidBegin;

    // This should warn, because it is NSObject
    class UITextFieldProxy : NSObject
    {
        // But then we suppressed the warning
        [UnconditionalSuppressMessage("Memory", "MA0003")]
        public void OnEditingDidBegin(object sender, EventArgs e) { }
    }

I added code to look up the attribute on the method from this statement:

    new UITextField().EditingDidBegin += _proxy.OnEditingDidBegin;

This also uncovered a bug in the analyzer:

    --if (attribute.AttributeClass.ContainingNamespace.Name != "System.Diagnostics.CodeAnalysis")
    ++if (attribute.AttributeClass.ContainingNamespace.ToString() != "System.Diagnostics.CodeAnalysis")

In this example `Name` was just `"CodeAnalysis"`. I have no idea why, but using `.ToString()` instead was successful. All tests pass with this change, so I'm going with it.