### PR TITLE
Add NuGet Badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # memory-analyzers
 
+ [![NuGet](https://buildstats.info/nuget/MemoryAnalyzers?includePreReleases=true)](https://www.nuget.org/packages/MemoryAnalyzers/)
+
 A set of Roslyn C# code analyzers for finding memory leaks in iOS and
 MacCatalyst applications.
 


### PR DESCRIPTION
Hey Jonathan! 

Thanks for making the `MemoryAnalyzers` NuGet Package - I love it! I just opened a PR to add it to `CommunityToolkit.Maui` to help us squash any potential memory leaks too 🙌: https://github.com/CommunityToolkit/Maui/pull/1371

This PR just adds the NuGet Badge to the README. Long story short, when I discovered this repo today, I at first didn't realize it was already published to NuGet and had to do some digging to find it. Hopefully this helps future devs find your NuGet package too! 