### PR TITLE
Use `MEM0001`, `MEM0002`, `MEM0003` error codes

### DIFF
--- a/MemoryAnalyzers/MemoryAnalyzers.CodeFixes/MemoryAnalyzersCodeFixProvider.cs
+++ b/MemoryAnalyzers/MemoryAnalyzers.CodeFixes/MemoryAnalyzersCodeFixProvider.cs
@@ -17,7 +17,7 @@ namespace MemoryAnalyzers
 	{
 		public sealed override ImmutableArray<string> FixableDiagnosticIds
 		{
-			get { return ImmutableArray.Create(MemoryAnalyzer.MA0001, MemoryAnalyzer.MA0002, MemoryAnalyzer.MA0003); }
+			get { return ImmutableArray.Create(MemoryAnalyzer.MEM0001, MemoryAnalyzer.MEM0002, MemoryAnalyzer.MEM0003); }
 		}
 
 		public sealed override FixAllProvider GetFixAllProvider()
@@ -37,7 +37,7 @@ namespace MemoryAnalyzers
 			if (parent is null)
 				return;
 
-			if (diagnostic.Id == MemoryAnalyzer.MA0001)
+			if (diagnostic.Id == MemoryAnalyzer.MEM0001)
 			{
 				var declaration = parent.AncestorsAndSelf().OfType<EventFieldDeclarationSyntax>().First();
 				context.RegisterCodeFix(
@@ -53,7 +53,7 @@ namespace MemoryAnalyzers
 						equivalenceKey: nameof(CodeFixResources.AddUnconditionalSuppressMessage)),
 					diagnostic);
 			}
-			else if (diagnostic.Id == MemoryAnalyzer.MA0002)
+			else if (diagnostic.Id == MemoryAnalyzer.MEM0002)
 			{
 				var declaration = parent.AncestorsAndSelf().OfType<MemberDeclarationSyntax>().First();
 				context.RegisterCodeFix(
@@ -75,7 +75,7 @@ namespace MemoryAnalyzers
 						equivalenceKey: nameof(CodeFixResources.MakeWeak)),
 					diagnostic);
 			}
-			else if (diagnostic.Id == MemoryAnalyzer.MA0003)
+			else if (diagnostic.Id == MemoryAnalyzer.MEM0003)
 			{
 				var declaration = parent.AncestorsAndSelf().OfType<AssignmentExpressionSyntax>().First();
 				if (declaration.Parent is null)

--- a/MemoryAnalyzers/MemoryAnalyzers.Test/CodeFixUnitTests.cs
+++ b/MemoryAnalyzers/MemoryAnalyzers.Test/CodeFixUnitTests.cs
@@ -10,7 +10,7 @@ namespace MemoryAnalyzers.Test
 	public class CodeFixUnitTests
 	{
 		[TestMethod]
-		public async Task MA0001_Remove()
+		public async Task MEM0001_Remove()
 		{
 			var test = """
 			class Foo : NSObject
@@ -26,12 +26,12 @@ namespace MemoryAnalyzers.Test
 			}
 			""";
 
-			var expected = VerifyCS.Diagnostic("MA0001").WithLocation(0).WithArguments("EventName");
+			var expected = VerifyCS.Diagnostic("MEM0001").WithLocation(0).WithArguments("EventName");
 			await VerifyCS.VerifyCodeFixAsync(test, expected, codefix, index: 0);
 		}
 
 		[TestMethod]
-		public async Task MA0001_UnconditionalSuppressMessage()
+		public async Task MEM0001_UnconditionalSuppressMessage()
 		{
 			var test = """
 			class Foo : NSObject
@@ -43,17 +43,17 @@ namespace MemoryAnalyzers.Test
 			var codefix = """
 			class Foo : NSObject
 			{
-			    [UnconditionalSuppressMessage("Memory", "MA0001", Justification = "Proven safe in test: XYZ")]
+			    [UnconditionalSuppressMessage("Memory", "MEM0001", Justification = "Proven safe in test: XYZ")]
 			    public event EventHandler {|#0:EventName|};
 			}
 			""";
 
-			var expected = VerifyCS.Diagnostic("MA0001").WithLocation(0).WithArguments("EventName");
+			var expected = VerifyCS.Diagnostic("MEM0001").WithLocation(0).WithArguments("EventName");
 			await VerifyCS.VerifyCodeFixAsync(test, expected, codefix, index: 1);
 		}
 
 		[TestMethod]
-		public async Task MA0002_Remove()
+		public async Task MEM0002_Remove()
 		{
 			var test = """
 			class Foo : NSObject
@@ -69,12 +69,12 @@ namespace MemoryAnalyzers.Test
 			}
 			""";
 
-			var expected = VerifyCS.Diagnostic("MA0002").WithLocation(0).WithArguments("FieldName");
+			var expected = VerifyCS.Diagnostic("MEM0002").WithLocation(0).WithArguments("FieldName");
 			await VerifyCS.VerifyCodeFixAsync(test, expected, codefix, index: 0);
 		}
 
 		[TestMethod]
-		public async Task MA0002_UnconditionalSuppressMessage()
+		public async Task MEM0002_UnconditionalSuppressMessage()
 		{
 			var test = """
 			class Foo : NSObject
@@ -86,17 +86,17 @@ namespace MemoryAnalyzers.Test
 			var codefix = """
 			class Foo : NSObject
 			{
-			    [UnconditionalSuppressMessage("Memory", "MA0002", Justification = "Proven safe in test: XYZ")]
+			    [UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Proven safe in test: XYZ")]
 			    public UIView {|#0:FieldName|};
 			}
 			""";
 
-			var expected = VerifyCS.Diagnostic("MA0002").WithLocation(0).WithArguments("FieldName");
+			var expected = VerifyCS.Diagnostic("MEM0002").WithLocation(0).WithArguments("FieldName");
 			await VerifyCS.VerifyCodeFixAsync(test, expected, codefix, index: 1);
 		}
 
 		[TestMethod]
-		public async Task MA0002_MakeWeak_Field()
+		public async Task MEM0002_MakeWeak_Field()
 		{
 			var test = """
 			class Foo : NSObject
@@ -112,12 +112,12 @@ namespace MemoryAnalyzers.Test
 			}
 			""";
 
-			var expected = VerifyCS.Diagnostic("MA0002").WithLocation(0).WithArguments("FieldName");
+			var expected = VerifyCS.Diagnostic("MEM0002").WithLocation(0).WithArguments("FieldName");
 			await VerifyCS.VerifyCodeFixAsync(test, expected, codefix, index: 2);
 		}
 
 		[TestMethod]
-		public async Task MA0002_MakeWeak_Property()
+		public async Task MEM0002_MakeWeak_Property()
 		{
 			var test = """
 			class Foo : NSObject
@@ -133,12 +133,12 @@ namespace MemoryAnalyzers.Test
 			}
 			""";
 
-			var expected = VerifyCS.Diagnostic("MA0002").WithLocation(0).WithArguments("FieldName");
+			var expected = VerifyCS.Diagnostic("MEM0002").WithLocation(0).WithArguments("FieldName");
 			await VerifyCS.VerifyCodeFixAsync(test, expected, codefix, index: 2);
 		}
 
 		[TestMethod]
-		public async Task MA0003_Remove()
+		public async Task MEM0003_Remove()
 		{
 			var test = """
 			using System.Diagnostics.CodeAnalysis;
@@ -146,7 +146,7 @@ namespace MemoryAnalyzers.Test
 			[Register("UITextField", true)]
 			class UITextField
 			{
-			    [UnconditionalSuppressMessage("Memory", "MA0001")]
+			    [UnconditionalSuppressMessage("Memory", "MEM0001")]
 			    public event EventHandler EditingDidBegin;
 			}
 
@@ -169,7 +169,7 @@ namespace MemoryAnalyzers.Test
 			[Register("UITextField", true)]
 			class UITextField
 			{
-			    [UnconditionalSuppressMessage("Memory", "MA0001")]
+			    [UnconditionalSuppressMessage("Memory", "MEM0001")]
 			    public event EventHandler EditingDidBegin;
 			}
 
@@ -186,12 +186,12 @@ namespace MemoryAnalyzers.Test
 			}
 			""";
 
-			var expected = VerifyCS.Diagnostic("MA0003").WithLocation(0).WithArguments("OnEditingDidBegin");
+			var expected = VerifyCS.Diagnostic("MEM0003").WithLocation(0).WithArguments("OnEditingDidBegin");
 			await VerifyCS.VerifyCodeFixAsync(test, expected, codefix, index: 0);
 		}
 
 		[TestMethod]
-		public async Task MA0003_MakeStatic()
+		public async Task MEM0003_MakeStatic()
 		{
 			var test = """
 			using System.Diagnostics.CodeAnalysis;
@@ -199,7 +199,7 @@ namespace MemoryAnalyzers.Test
 			[Register("UITextField", true)]
 			class UITextField
 			{
-			    [UnconditionalSuppressMessage("Memory", "MA0001")]
+			    [UnconditionalSuppressMessage("Memory", "MEM0001")]
 			    public event EventHandler EditingDidBegin;
 			}
 
@@ -222,7 +222,7 @@ namespace MemoryAnalyzers.Test
 			[Register("UITextField", true)]
 			class UITextField
 			{
-			    [UnconditionalSuppressMessage("Memory", "MA0001")]
+			    [UnconditionalSuppressMessage("Memory", "MEM0001")]
 			    public event EventHandler EditingDidBegin;
 			}
 
@@ -239,7 +239,7 @@ namespace MemoryAnalyzers.Test
 			}
 			""";
 
-			var expected = VerifyCS.Diagnostic("MA0003").WithLocation(0).WithArguments("OnEditingDidBegin");
+			var expected = VerifyCS.Diagnostic("MEM0003").WithLocation(0).WithArguments("OnEditingDidBegin");
 			await VerifyCS.VerifyCodeFixAsync(test, expected, codefix, index: 1);
 		}
 	}

--- a/MemoryAnalyzers/MemoryAnalyzers.Test/MemoryAnalyzersUnitTests.cs
+++ b/MemoryAnalyzers/MemoryAnalyzers.Test/MemoryAnalyzersUnitTests.cs
@@ -38,8 +38,23 @@ namespace MemoryAnalyzers.Test
 				}
 			""";
 
-			var expected = VerifyCS.Diagnostic("MA0001").WithLocation(0).WithArguments("EventName");
+			var expected = VerifyCS.Diagnostic("MEM0001").WithLocation(0).WithArguments("EventName");
 			await VerifyCS.VerifyAnalyzerAsync(test, expected);
+		}
+
+		[TestMethod]
+		public async Task UnconditionalSuppressMessage_MEM0001()
+		{
+			var test = """
+				class Foo : NSObject
+				{
+					[UnconditionalSuppressMessage("Memory", "MEM0001")]
+					public event EventHandler {|#0:EventName|};
+				}
+			""";
+
+			// 0 warnings
+			await VerifyCS.VerifyAnalyzerAsync(test);
 		}
 
 		[TestMethod]
@@ -58,12 +73,12 @@ namespace MemoryAnalyzers.Test
 		}
 
 		[TestMethod]
-		public async Task UnconditionalSuppressMessage_MA0001_Justification()
+		public async Task UnconditionalSuppressMessage_MEM0001_Justification()
 		{
 			var test = """
 				class Foo : NSObject
 				{
-					[UnconditionalSuppressMessage("Memory", "MA0001", Justification = "I know what I'm doing! LOL?")]
+					[UnconditionalSuppressMessage("Memory", "MEM0001", Justification = "I know what I'm doing! LOL?")]
 					public event EventHandler {|#0:EventName|};
 				}
 			""";
@@ -83,7 +98,7 @@ namespace MemoryAnalyzers.Test
 				}
 			""";
 
-			var expected = VerifyCS.Diagnostic("MA0001").WithLocation(0).WithArguments("EventName");
+			var expected = VerifyCS.Diagnostic("MEM0001").WithLocation(0).WithArguments("EventName");
 			await VerifyCS.VerifyAnalyzerAsync(test, expected);
 		}
 
@@ -132,7 +147,7 @@ namespace MemoryAnalyzers.Test
 				}
 			""";
 
-			var expected = VerifyCS.Diagnostic("MA0001").WithLocation(0).WithArguments("EventName");
+			var expected = VerifyCS.Diagnostic("MEM0001").WithLocation(0).WithArguments("EventName");
 			await VerifyCS.VerifyAnalyzerAsync(test, expected);
 		}
 
@@ -148,7 +163,7 @@ namespace MemoryAnalyzers.Test
 				}
 			""";
 
-			var expected = VerifyCS.Diagnostic("MA0001").WithLocation(0).WithArguments("EventName");
+			var expected = VerifyCS.Diagnostic("MEM0001").WithLocation(0).WithArguments("EventName");
 			await VerifyCS.VerifyAnalyzerAsync(test, expected);
 		}
 
@@ -162,7 +177,7 @@ namespace MemoryAnalyzers.Test
 				}
 			""";
 
-			var expected = VerifyCS.Diagnostic("MA0002").WithLocation(0).WithArguments("FieldName");
+			var expected = VerifyCS.Diagnostic("MEM0002").WithLocation(0).WithArguments("FieldName");
 			await VerifyCS.VerifyAnalyzerAsync(test, expected);
 		}
 
@@ -176,7 +191,7 @@ namespace MemoryAnalyzers.Test
 				}
 			""";
 
-			var expected = VerifyCS.Diagnostic("MA0002").WithLocation(0).WithArguments("FieldName");
+			var expected = VerifyCS.Diagnostic("MEM0002").WithLocation(0).WithArguments("FieldName");
 			await VerifyCS.VerifyAnalyzerAsync(test, expected);
 		}
 
@@ -190,7 +205,7 @@ namespace MemoryAnalyzers.Test
 				}
 			""";
 
-			var expected = VerifyCS.Diagnostic("MA0002").WithLocation(0).WithArguments("FieldName");
+			var expected = VerifyCS.Diagnostic("MEM0002").WithLocation(0).WithArguments("FieldName");
 			await VerifyCS.VerifyAnalyzerAsync(test, expected);
 		}
 
@@ -247,6 +262,20 @@ namespace MemoryAnalyzers.Test
 		}
 
 		[TestMethod]
+		public async Task UnconditionalSuppressMessage_MEM0002_Field()
+		{
+			var test = """
+				class MyViewSubclass : UIView
+				{
+					[UnconditionalSuppressMessage("Memory", "MEM0002")]
+					public UIView {|#0:FieldName|};
+				}
+			""";
+
+			await VerifyCS.VerifyAnalyzerAsync(test);
+		}
+
+		[TestMethod]
 		public async Task UnconditionalSuppressMessage_MA0002_Field()
 		{
 			var test = """
@@ -270,7 +299,7 @@ namespace MemoryAnalyzers.Test
 				}
 			""";
 
-			var expected = VerifyCS.Diagnostic("MA0002").WithLocation(0).WithArguments("PropertyName");
+			var expected = VerifyCS.Diagnostic("MEM0002").WithLocation(0).WithArguments("PropertyName");
 			await VerifyCS.VerifyAnalyzerAsync(test, expected);
 		}
 
@@ -284,7 +313,7 @@ namespace MemoryAnalyzers.Test
 				}
 			""";
 
-			var expected = VerifyCS.Diagnostic("MA0002").WithLocation(0).WithArguments("PropertyName");
+			var expected = VerifyCS.Diagnostic("MEM0002").WithLocation(0).WithArguments("PropertyName");
 			await VerifyCS.VerifyAnalyzerAsync(test, expected);
 		}
 
@@ -298,7 +327,7 @@ namespace MemoryAnalyzers.Test
 				}
 			""";
 
-			var expected = VerifyCS.Diagnostic("MA0002").WithLocation(0).WithArguments("PropertyName");
+			var expected = VerifyCS.Diagnostic("MEM0002").WithLocation(0).WithArguments("PropertyName");
 			await VerifyCS.VerifyAnalyzerAsync(test, expected);
 		}
 
@@ -368,6 +397,20 @@ namespace MemoryAnalyzers.Test
 		}
 
 		[TestMethod]
+		public async Task UnconditionalSuppressMessage_MEM0002_Property()
+		{
+			var test = """
+				class MyViewSubclass : UIView
+				{
+					[UnconditionalSuppressMessage("Memory", "MEM0002")]
+					public UIView {|#0:PropertyName|} { get; set; }
+				}
+			""";
+
+			await VerifyCS.VerifyAnalyzerAsync(test);
+		}
+
+		[TestMethod]
 		public async Task UnconditionalSuppressMessage_MA0002_Property()
 		{
 			var test = """
@@ -388,7 +431,7 @@ namespace MemoryAnalyzers.Test
 				[Register(Name = "UITextField", IsWrapper = true)]
 				class UITextField
 				{
-					[UnconditionalSuppressMessage("Memory", "MA0001")]
+					[UnconditionalSuppressMessage("Memory", "MEM0001")]
 					public event EventHandler EditingDidBegin;
 				}
 
@@ -403,7 +446,7 @@ namespace MemoryAnalyzers.Test
 				}
 			""";
 
-			var expected = VerifyCS.Diagnostic("MA0003").WithLocation(0).WithArguments("OnEditingDidBegin");
+			var expected = VerifyCS.Diagnostic("MEM0003").WithLocation(0).WithArguments("OnEditingDidBegin");
 			await VerifyCS.VerifyAnalyzerAsync(test, expected);
 		}
 
@@ -414,7 +457,7 @@ namespace MemoryAnalyzers.Test
 				[Register(Name = "UITextField", IsWrapper = true)]
 				class UITextField
 				{
-					[UnconditionalSuppressMessage("Memory", "MA0001")]
+					[UnconditionalSuppressMessage("Memory", "MEM0001")]
 					public event EventHandler EditingDidBegin;
 				}
 
@@ -430,7 +473,7 @@ namespace MemoryAnalyzers.Test
 				}
 			""";
 
-			var expected = VerifyCS.Diagnostic("MA0003").WithLocation(0).WithArguments("OnEditingDidBegin");
+			var expected = VerifyCS.Diagnostic("MEM0003").WithLocation(0).WithArguments("OnEditingDidBegin");
 			await VerifyCS.VerifyAnalyzerAsync(test, expected);
 		}
 
@@ -441,19 +484,19 @@ namespace MemoryAnalyzers.Test
 				[Register(Name = "UITextField", IsWrapper = true)]
 				class UITextField
 				{
-					[UnconditionalSuppressMessage("Memory", "MA0001")]
+					[UnconditionalSuppressMessage("Memory", "MEM0001")]
 					public event EventHandler EditingDidBegin;
 				}
 
 				class MySubclass : UIView
 				{
-					[UnconditionalSuppressMessage("Memory", "MA0001")]
+					[UnconditionalSuppressMessage("Memory", "MEM0001")]
 					public event EventHandler InheritedEvent;
 				}
 
 				class MyView : MySubclass
 				{
-					[UnconditionalSuppressMessage("Memory", "MA0001")]
+					[UnconditionalSuppressMessage("Memory", "MEM0001")]
 					public event EventHandler MyOwnedEvent;
 
 					event EventHandler MyPrivateEvent;
@@ -486,7 +529,7 @@ namespace MemoryAnalyzers.Test
 				[Register("UIControl", true)]
 				class UIControl
 				{
-					[UnconditionalSuppressMessage("Memory", "MA0001")]
+					[UnconditionalSuppressMessage("Memory", "MEM0001")]
 					public event EventHandler ValueChanged;
 				}
 
@@ -516,7 +559,7 @@ namespace MemoryAnalyzers.Test
 				}
 			""";
 
-			var expected = VerifyCS.Diagnostic("MA0003").WithLocation(0).WithArguments("OnValueChanged");
+			var expected = VerifyCS.Diagnostic("MEM0003").WithLocation(0).WithArguments("OnValueChanged");
 			await VerifyCS.VerifyAnalyzerAsync(test, expected);
 		}
 
@@ -530,7 +573,7 @@ namespace MemoryAnalyzers.Test
 				[Register(Name = "UITextField", IsWrapper = true)]
 				class UITextField
 				{
-					[UnconditionalSuppressMessage("Memory", "MA0001")]
+					[UnconditionalSuppressMessage("Memory", "MEM0001")]
 					public event EventHandler EditingDidBegin;
 				}
 
@@ -560,13 +603,13 @@ namespace MemoryAnalyzers.Test
 				[Register(Name = "UITextField", IsWrapper = true)]
 				class UITextField
 				{
-					[UnconditionalSuppressMessage("Memory", "MA0001")]
+					[UnconditionalSuppressMessage("Memory", "MEM0001")]
 					public event EventHandler EditingDidBegin;
 				}
 
 				class MyView : UIView
 				{
-					[UnconditionalSuppressMessage("Memory", "MA0002")]
+					[UnconditionalSuppressMessage("Memory", "MEM0002")]
 					readonly UITextFieldProxy _proxy = new();
 
 					public MyView()
@@ -582,7 +625,7 @@ namespace MemoryAnalyzers.Test
 				}
 			""";
 
-			var expected = VerifyCS.Diagnostic("MA0003").WithLocation(0).WithArguments("OnEditingDidBegin");
+			var expected = VerifyCS.Diagnostic("MEM0003").WithLocation(0).WithArguments("OnEditingDidBegin");
 			await VerifyCS.VerifyAnalyzerAsync(test, expected);
 		}
 
@@ -593,13 +636,13 @@ namespace MemoryAnalyzers.Test
 				[Register(Name = "UITextField", IsWrapper = true)]
 				class UITextField
 				{
-					[UnconditionalSuppressMessage("Memory", "MA0001")]
+					[UnconditionalSuppressMessage("Memory", "MEM0001")]
 					public event EventHandler EditingDidBegin;
 				}
 
 				class MyView : UIView
 				{
-					[UnconditionalSuppressMessage("Memory", "MA0002")]
+					[UnconditionalSuppressMessage("Memory", "MEM0002")]
 					readonly UITextFieldProxy _proxy = new();
 
 					public MyView()
@@ -611,7 +654,7 @@ namespace MemoryAnalyzers.Test
 					class UITextFieldProxy : NSObject
 					{
 						// But then we suppressed the warning
-						[UnconditionalSuppressMessage("Memory", "MA0003")]
+						[UnconditionalSuppressMessage("Memory", "MEM0003")]
 						public void OnEditingDidBegin(object sender, EventArgs e) { }
 					}
 				}

--- a/MemoryAnalyzers/MemoryAnalyzers/AnalyzerReleases.Shipped.md
+++ b/MemoryAnalyzers/MemoryAnalyzers/AnalyzerReleases.Shipped.md
@@ -1,3 +1,10 @@
 ﻿; Shipped analyzer releases
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
 
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+MA0001 | Memory | Warning | C# events can cause memory leaks in an NSObject subclass. Remove the event or add the [UnconditionalSuppressMessage("Memory", "MA0001")] attribute with a justification as to why the event will not leak.
+MA0002 | Memory | Warning | Reference type members can cause memory leaks in an NSObject subclass. Remove the member, store the value as a WeakReference, or add the [UnconditionalSuppressMessage("Memory", "MA0002")] attribute with a justification as to why the member will not leak.
+MA0003 | Memory | Warning | Subscribing to events with instance methods can cause memory leaks in an NSObject subclass. Remove the subscription or convert the method to a static method.

--- a/MemoryAnalyzers/MemoryAnalyzers/AnalyzerReleases.Unshipped.md
+++ b/MemoryAnalyzers/MemoryAnalyzers/AnalyzerReleases.Unshipped.md
@@ -5,6 +5,6 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
-MA0001 | Memory | Warning | C# events can cause memory leaks in an NSObject subclass. Remove the event or add the [UnconditionalSuppressMessage("Memory", "MA0001")] attribute with a justification as to why the event will not leak.
-MA0002 | Memory | Warning | Reference type members can cause memory leaks in an NSObject subclass. Remove the member, store the value as a WeakReference, or add the [UnconditionalSuppressMessage("Memory", "MA0002")] attribute with a justification as to why the member will not leak.
-MA0003 | Memory | Warning | Subscribing to events with instance methods can cause memory leaks in an NSObject subclass. Remove the subscription or convert the method to a static method.
+MEM0001 | Memory | Warning | C# events can cause memory leaks in an NSObject subclass. Remove the event or add the [UnconditionalSuppressMessage("Memory", "MA0001")] attribute with a justification as to why the event will not leak.
+MEM0002 | Memory | Warning | Reference type members can cause memory leaks in an NSObject subclass. Remove the member, store the value as a WeakReference, or add the [UnconditionalSuppressMessage("Memory", "MA0002")] attribute with a justification as to why the member will not leak.
+MEM0003 | Memory | Warning | Subscribing to events with instance methods can cause memory leaks in an NSObject subclass. Remove the subscription or convert the method to a static method.


### PR DESCRIPTION
Fixes: https://github.com/jonathanpeppers/memory-analyzers/issues/6

I still support `MA0001`, etc. as a way to silence the warnings. This will make it easier to migrate the dotnet/maui repo.