### PR TITLE
Emit warnings for C# interfaces

### DIFF
--- a/MemoryAnalyzers/MemoryAnalyzers.Test/MemoryAnalyzersUnitTests.cs
+++ b/MemoryAnalyzers/MemoryAnalyzers.Test/MemoryAnalyzersUnitTests.cs
@@ -196,6 +196,22 @@ namespace MemoryAnalyzers.Test
 		}
 
 		[TestMethod]
+		public async Task FieldThatLeaks_Interface()
+		{
+			var test = """
+				interface IFoo { }
+
+				class MyViewSubclass : UIView
+				{
+					public IFoo {|#0:FieldName|};
+				}
+			""";
+
+			var expected = VerifyCS.Diagnostic("MEM0002").WithLocation(0).WithArguments("FieldName");
+			await VerifyCS.VerifyAnalyzerAsync(test, expected);
+		}
+
+		[TestMethod]
 		public async Task FieldThatLeaks_Delegate()
 		{
 			var test = """
@@ -310,6 +326,22 @@ namespace MemoryAnalyzers.Test
 				class MyViewSubclass : UIView
 				{
 					public object {|#0:PropertyName|} { get; set; }
+				}
+			""";
+
+			var expected = VerifyCS.Diagnostic("MEM0002").WithLocation(0).WithArguments("PropertyName");
+			await VerifyCS.VerifyAnalyzerAsync(test, expected);
+		}
+
+		[TestMethod]
+		public async Task PropertyThatLeaks_Interface()
+		{
+			var test = """
+				interface IFoo { }
+
+				class MyViewSubclass : UIView
+				{
+					public IFoo {|#0:PropertyName|} { get; set; }
 				}
 			""";
 

--- a/MemoryAnalyzers/MemoryAnalyzers/MemoryAnalyzer.cs
+++ b/MemoryAnalyzers/MemoryAnalyzers/MemoryAnalyzer.cs
@@ -132,7 +132,7 @@ namespace MemoryAnalyzers
 			{
 				if (GenerallySafe.Contains((namedSymbol.ContainingNamespace.Name, namedSymbol.Name)))
 					return;
-				if (!IsObject(namedSymbol) && !IsDelegateType(namedSymbol) && !IsNSObjectSubclass(namedSymbol))
+				if (namedSymbol.TypeKind != TypeKind.Interface && !IsObject(namedSymbol) && !IsDelegateType(namedSymbol) && !IsNSObjectSubclass(namedSymbol))
 					return;
 				if (IsGenerallySafe(symbol.ContainingType, symbol.Type))
 					return;
@@ -158,7 +158,7 @@ namespace MemoryAnalyzers
 			{
 				if (GenerallySafe.Contains((namedSymbol.ContainingNamespace.Name, namedSymbol.Name)))
 					return;
-				if (!IsObject(namedSymbol) && !IsDelegateType(namedSymbol) && !IsNSObjectSubclass(namedSymbol))
+				if (namedSymbol.TypeKind != TypeKind.Interface && !IsObject(namedSymbol) && !IsDelegateType(namedSymbol) && !IsNSObjectSubclass(namedSymbol))
 					return;
 				if (IsGenerallySafe(symbol.ContainingType, symbol.Type))
 					return;


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/pull/18434#discussion_r1376401448

This situation came up in .NET MAUI. You can create circular references with interfaces, as any `NSObject` can implement an interface. Warn about interfaces.